### PR TITLE
Fix small typo in en.json

### DIFF
--- a/BeamJoyCore/lang/en.json
+++ b/BeamJoyCore/lang/en.json
@@ -181,7 +181,7 @@
     },
     "mapSwitch": {
       "missingArchive": "The archive is missing",
-      "kickIn": "The map is about to change, you will be kick in {delay}",
+      "kickIn": "The map is about to change, you will be kicked in {delay}",
       "kick": "The map has changed, please reconnect"
     },
     "broadcast": {


### PR DESCRIPTION
Fixed a typo from "you will be kick" to "you will be kicked"