### PR TITLE
Add Dockerfile and build workflow

### DIFF
--- a/.github/.workflows/docker-build.yml
+++ b/.github/.workflows/docker-build.yml
@@ -6,7 +6,7 @@ on:
       beamjoy_version:
         description: 'BeamJoy version to build (e.g., 2.0.6)'
         required: true
-        default: '2.0.6'
+        default: '2.0.6-full'
         type: string
       beamjoy_file_name:
         description: 'BeamJoy file name (e.g., beamjoy-2.0.6.zip)'
@@ -16,7 +16,7 @@ on:
       datapack_version:
         description: 'Datapack version to build (e.g., 2025-07-18)'
         required: true
-        default: '2025-07-18'
+        default: 'datapack-2025-07-18'
         type: string
       datapack_file_name:
         description: 'Datapack file name (e.g., BeamJoy_BaseGame_Data_2.0.0_2025-07-18_no-race-records.zip)'

--- a/.github/.workflows/docker-build.yml
+++ b/.github/.workflows/docker-build.yml
@@ -1,0 +1,79 @@
+name: Build and Push Multi-Arch Docker Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      beamjoy_version:
+        description: 'BeamJoy version to build (e.g., 2.0.6)'
+        required: true
+        default: '2.0.6'
+        type: string
+      beamjoy_file_name:
+        description: 'BeamJoy file name (e.g., beamjoy-2.0.6.zip)'
+        required: true
+        default: 'beamjoy-2.0.6.zip'
+        type: string
+      datapack_version:
+        description: 'Datapack version to build (e.g., 2025-07-18)'
+        required: true
+        default: '2025-07-18'
+        type: string
+      datapack_file_name:
+        description: 'Datapack file name (e.g., BeamJoy_BaseGame_Data_2.0.0_2025-07-18_no-race-records.zip)'
+        required: true
+        default: 'BeamJoy_BaseGame_Data_2.0.0_2025-07-18_no-race-records.zip'
+        type: string
+      image_tag:
+        description: 'Custom image tag (optional, defaults to beamjoy version)'
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=raw,value=${{ inputs.image_tag || inputs.beamjoy_version }}
+          type=raw,value=latest,enable=${{ inputs.image_tag == '' }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        build-args: |
+          BEAMJOY_VERSION=${{ inputs.beamjoy_version }}
+          BEAMJOY_FILE_NAME=${{ inputs.beamjoy_file_name }}
+          DATAPACK_VERSION=${{ inputs.datapack_version }}
+          DATAPACK_FILE_NAME=${{ inputs.datapack_file_name }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM rouhim/beammp-server:latest
+
+# Build arguments for dynamic versioning
+ARG BEAMJOY_VERSION
+ARG BEAMJOY_FILE_NAME
+ARG DATAPACK_VERSION
+ARG DATAPACK_FILE_NAME
+
+# Switch to root for package installation and file operations
+USER root
+
+# Install dependencies and download/extract BeamJoy in a single layer
+RUN apt-get update && \
+    apt-get install -y wget unzip && \
+    \
+    # Download and extract BeamJoy
+    cd /beammp/Resources && \
+    wget https://github.com/my-name-is-samael/BeamJoy/releases/download/${BEAMJOY_VERSION}/${BEAMJOY_FILE_NAME} && \
+    unzip ${BEAMJOY_FILE_NAME} && \
+    rm ${BEAMJOY_FILE_NAME} && \
+    \
+    # Create directory and download/extract datapack
+    mkdir -p /beammp/Resources/Server/BeamJoyData/db/scenarii && \
+    cd /beammp/Resources/Server/BeamJoyData/db/scenarii && \
+    wget https://github.com/my-name-is-samael/BeamJoy/releases/download/${DATAPACK_VERSION}/${DATAPACK_FILE_NAME} && \
+    unzip ${DATAPACK_FILE_NAME} && \
+    rm ${DATAPACK_FILE_NAME} && \
+    \
+    # Set proper ownership and remove russian language
+    chown -R ubuntu:ubuntu /beammp/Resources/Client /beammp/Resources/Server && \
+    rm -f /beammp/Resources/Server/BeamJoyCore/lang/ru.json
+
+# Set working directory and switch back to ubuntu user
+WORKDIR /beammp
+USER ubuntu


### PR DESCRIPTION
Hi, 
Here is my proposal how you can also make this mod available via docker container and published into GitHub image repository.
You can pass different arguments to create different containers, for example include datapack with racing records or without. It builds container for both architectures arm64 and amd64. It builds it on top of rouhim/beammp-server:latest
Anyway if you don't like it or anything or want some changes lmk. 

P.S. Good work btw. When will you add progression 😄  ?